### PR TITLE
fix(mcp): boot stdio server when invoked via cavemem mcp

### DIFF
--- a/.changeset/fix-mcp-cli-import.md
+++ b/.changeset/fix-mcp-cli-import.md
@@ -1,0 +1,14 @@
+---
+"cavemem": patch
+"@cavemem/mcp-server": patch
+---
+
+fix(mcp): boot stdio server when invoked via `cavemem mcp`
+
+The CLI's `mcp` subcommand did `await import('@cavemem/mcp-server')` expecting
+the import side-effect to start the server, but the server module guards
+`main()` behind an `isMainEntry()` check. When dynamically imported,
+`import.meta.url` does not match `process.argv[1]` (the CLI), so `main()`
+never ran and no MCP tools were exposed to the host IDE. Export `main()` from
+the server module and have the CLI call it explicitly. The `isMainEntry()`
+guard remains so the `cavemem-mcp` bin still works when invoked directly.

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -5,7 +5,10 @@ export function registerMcpCommand(program: Command): void {
     .command('mcp')
     .description('Run the MCP stdio server (typically invoked by the IDE)')
     .action(async () => {
-      // Delegate: importing runs main() via the server module.
-      await import('@cavemem/mcp-server');
+      // The server module guards `main()` behind an `isMainEntry()` check, so
+      // a bare dynamic import does not start the stdio server when invoked
+      // through the CLI. Pull `main` out and call it explicitly.
+      const { main } = await import('@cavemem/mcp-server');
+      await main();
     });
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -116,7 +116,7 @@ export function buildServer(store: MemoryStore, settings: Settings): McpServer {
   return server;
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const settings = loadSettings();
   const dbPath = join(resolveDataDir(settings.dataDir), 'data.db');
   const store = new MemoryStore({ dbPath, settings });

--- a/apps/mcp-server/test/exports.test.ts
+++ b/apps/mcp-server/test/exports.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+describe('MCP server module exports', () => {
+  it('exports main() so the CLI can boot the stdio server', async () => {
+    const mod = await import('../src/server.js');
+    expect(typeof mod.main).toBe('function');
+  });
+
+  it('still exports buildServer for in-process inspector tests', async () => {
+    const mod = await import('../src/server.js');
+    expect(typeof mod.buildServer).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- `cavemem mcp` exits silently without ever connecting an MCP stdio transport.
- Root cause: the CLI's `mcp` command does `await import('@cavemem/mcp-server')` expecting the import side-effect to start the server, but `main()` is guarded behind `isMainEntry()`, which returns false for dynamic imports.
- Fix: export `main()` and call it explicitly from the CLI.

## Repro

```bash
# Expected: stays running, serves JSON-RPC over stdio.
# Actual:   exits 0 immediately, transport never connects.
cavemem mcp
```

Or, with an explicit MCP `initialize` handshake:

```bash
printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}' \
  | cavemem mcp
# (no response — server never started)
```

Any host that connects to `cavemem mcp` over the standard MCP stdio transport sees zero tools.

## Root cause
`apps/mcp-server/src/server.ts` guards `main()` behind an `isMainEntry()` check:

```ts
if (isMainEntry()) {
  main().catch(...);
}

function isMainEntry(): boolean {
  // import.meta.url = .../mcp-server/dist/server.js
  // process.argv[1]  = .../cli/dist/index.js  (when spawned via `cavemem mcp`)
  return import.meta.url === pathToFileURL(realpathSync(argv)).href;
}
```

`apps/cli/src/commands/mcp.ts` (before this PR):

```ts
// Delegate: importing runs main() via the server module.
await import('@cavemem/mcp-server');
```

The comment is wrong — dynamic import never runs `main()` because `isMainEntry()` returns false when the module is loaded through the CLI bundle. As a result, the stdio transport is never connected.

## Fix
Export `main` from the server module and have the CLI call it explicitly. The `isMainEntry()` guard is preserved so the `cavemem-mcp` bin (direct invocation) still works.

## Changes
- `apps/mcp-server/src/server.ts`: `async function main` → `export async function main`
- `apps/cli/src/commands/mcp.ts`: import `{ main }` and call it
- `apps/mcp-server/test/exports.test.ts`: regression test pinning the `main` export
- `.changeset/fix-mcp-cli-import.md`: patch changeset for `cavemem` + `@cavemem/mcp-server`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` (biome) passes
- [x] `pnpm build` produces a `cavemem` dist whose `dist/index.js` calls `await import('./server-XXXX.js').main()` and whose server chunk emits `export { buildServer, main }`
- [x] `apps/mcp-server` tests pass (8 incl. new export pin)
- [x] `apps/cli` tests pass (4)
- [x] After packing + global install, `cavemem mcp` responds to a JSON-RPC `initialize` request with a valid handshake (server stays alive, lists 4 tools)
- [x] `cavemem-mcp` bin still works when invoked directly (regression check on the `isMainEntry()` path)