### PR TITLE
fix: scope search and session-start context to current project (cwd)

### DIFF
--- a/packages/core/src/memory-store.ts
+++ b/packages/core/src/memory-store.ts
@@ -16,10 +16,12 @@ export interface MemoryStoreOptions {
 export class MemoryStore {
   readonly storage: Storage;
   readonly settings: Settings;
+  currentCwd: string | null;
 
   constructor(opts: MemoryStoreOptions) {
     this.storage = new Storage(opts.dbPath);
     this.settings = opts.settings;
+    this.currentCwd = null;
   }
 
   close(): void {
@@ -29,6 +31,7 @@ export class MemoryStore {
   // --- sessions ---
 
   startSession(p: { id: string; ide: string; cwd: string | null }): void {
+    this.currentCwd = p.cwd;
     this.storage.createSession({
       id: p.id,
       ide: p.ide,
@@ -116,7 +119,7 @@ export class MemoryStore {
   async search(query: string, limit?: number, embedder?: Embedder): Promise<SearchResult[]> {
     const cap = limit ?? this.settings.search.defaultLimit;
     const alpha = this.settings.search.alpha;
-    const keyword = this.storage.searchFts(query, cap * 2);
+    const keyword = this.storage.searchFts(query, cap * 2, this.currentCwd);
     if (!embedder || this.settings.embedding.provider === 'none') {
       return keyword.slice(0, cap);
     }

--- a/packages/hooks/src/handlers/session-start.ts
+++ b/packages/hooks/src/handlers/session-start.ts
@@ -12,9 +12,9 @@ export async function sessionStart(store: MemoryStore, input: HookInput): Promis
   // For resume/clear/compact the agent already has its own context; injecting
   // a "Prior-session context" preface would be noisy and possibly stale.
   if (input.source && input.source !== 'startup') return '';
-  const recent = store.storage.listSessions(4);
+  const recent = store.storage.listSessions(30);
   const hints = recent
-    .filter((s) => s.id !== input.session_id)
+    .filter((s) => s.id !== input.session_id && s.cwd === input.cwd)
     .slice(0, 3)
     .map((s) => {
       const summaries = store.storage.listSummaries(s.id).slice(0, 1);

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -130,20 +130,31 @@ export class Storage {
 
   // --- search (BM25 via FTS5) ---
 
-  searchFts(query: string, limit = 10): SearchHit[] {
+  searchFts(query: string, limit = 10, cwd?: string | null): SearchHit[] {
     if (!query.trim()) return [];
-    const rows = this.db
-      .prepare(
-        `SELECT o.id, o.session_id, o.ts,
+    const hasCwd = !!cwd;
+    const sql = hasCwd
+      ? `SELECT o.id, o.session_id, o.ts,
+                snippet(observations_fts, 0, '[', ']', '…', 16) AS snippet,
+                bm25(observations_fts) AS score
+         FROM observations_fts
+         JOIN observations o ON o.id = observations_fts.rowid
+         JOIN sessions s ON s.id = o.session_id
+         WHERE observations_fts MATCH ? AND s.cwd = ?
+         ORDER BY score ASC
+         LIMIT ?`
+      : `SELECT o.id, o.session_id, o.ts,
                 snippet(observations_fts, 0, '[', ']', '…', 16) AS snippet,
                 bm25(observations_fts) AS score
          FROM observations_fts
          JOIN observations o ON o.id = observations_fts.rowid
          WHERE observations_fts MATCH ?
          ORDER BY score ASC
-         LIMIT ?`,
-      )
-      .all(sanitizeMatch(query), limit) as Array<{
+         LIMIT ?`;
+    const params: unknown[] = hasCwd
+      ? [sanitizeMatch(query), cwd, limit]
+      : [sanitizeMatch(query), limit];
+    const rows = this.db.prepare(sql).all(...params) as Array<{
       id: number;
       session_id: string;
       ts: number;


### PR DESCRIPTION
## Summary
- Prevents cross-project memory pollution by scoping BM25 search results and prior-session context hints to the current working directory
- Three changes across `storage`, `core`, and `hooks` packages

## Changes

**`packages/storage/src/storage.ts`** — `searchFts()` now accepts an optional `cwd` parameter. When provided, the SQL query joins `sessions` and filters by `s.cwd = ?`, scoping BM25 results to the current project.

**`packages/core/src/memory-store.ts`** — `MemoryStore` tracks `currentCwd` on each `startSession()` call and passes it through to `searchFts()`.

**`packages/hooks/src/handlers/session-start.ts`** — Prior-session context hints are now filtered by matching `cwd`, so a session in project A never gets injected with summaries from project B.

## Test plan
- [ ] Start a session in project A, confirm no project B context leaks in
- [ ] Search via MCP in project A, verify results are scoped
- [ ] Verify existing behavior unchanged when `cwd` is null (no project)

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)