### PR TITLE
fix: resolve Windows spawn EFTYPE (#11)

### DIFF
--- a/apps/cli/src/commands/lifecycle.ts
+++ b/apps/cli/src/commands/lifecycle.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { loadSettings, resolveDataDir } from '@cavemem/config';
 import type { Command } from 'commander';
 import kleur from 'kleur';
-import { resolveCliPath } from '../util/resolve.js';
+import { resolveCliPath, resolveCliScriptPath } from '../util/resolve.js';
 
 /**
  * Top-level `cavemem start|stop|restart|viewer` commands — matches the
@@ -54,10 +54,11 @@ function startWorker(silent = false): number | null {
     }
   }
   // Spawn `node <cli> worker run` so Windows doesn't try to exec a .js directly.
-  const child = spawn(process.execPath, [resolveCliPath(), 'worker', 'run'], {
+  const child = spawn(process.execPath, [resolveCliScriptPath(), 'worker', 'run'], {
     detached: true,
     stdio: 'ignore',
     env: process.env,
+    windowsHide: true,
   });
   child.unref();
   if (child.pid) writeFileSync(pf, String(child.pid));

--- a/apps/cli/src/commands/worker.ts
+++ b/apps/cli/src/commands/worker.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { loadSettings, resolveDataDir } from '@cavemem/config';
 import type { Command } from 'commander';
 import kleur from 'kleur';
-import { resolveCliPath } from '../util/resolve.js';
+import { resolveCliPath, resolveCliScriptPath } from '../util/resolve.js';
 
 function pidFile(): string {
   return join(resolveDataDir(loadSettings().dataDir), 'worker.pid');
@@ -37,10 +37,11 @@ export function registerWorkerCommand(program: Command): void {
       // Spawn `node <cli> worker run` — not `<cli> worker run` — because on
       // Windows the resolved cliPath is the .js file (npm's bin shim points
       // at it), and spawn() can't execute a .js directly → EFTYPE.
-      const child = spawn(process.execPath, [resolveCliPath(), 'worker', 'run'], {
+      const child = spawn(process.execPath, [resolveCliScriptPath(), 'worker', 'run'], {
         detached: true,
         stdio: 'ignore',
         env: process.env,
+        windowsHide: true,
       });
       child.unref();
       writeFileSync(pf, String(child.pid));

--- a/apps/cli/src/util/resolve.ts
+++ b/apps/cli/src/util/resolve.ts
@@ -1,4 +1,5 @@
 import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Absolute path to the cavemem CLI binary. The installer writes this into
@@ -12,4 +13,12 @@ export function resolveCliPath(): string {
   } catch {
     return argv1;
   }
+}
+
+/**
+ * Absolute path to the executing CLI Javascript bundle.
+ * Used internally to reliably spawn the background worker daemon.
+ */
+export function resolveCliScriptPath(): string {
+  return fileURLToPath(import.meta.url);
 }


### PR DESCRIPTION
## Summary
- `cavemem start` and `cavemem viewer` fail with a `spawn EFTYPE` error on Windows.
- Root cause: On Windows, `spawn()` can't directly execute `.js` wrapper scripts because `CreateProcess` doesn't honor Unix shebangs.
- Fix: explicitly invoke the Node binary with the absolute path to the `.js` bundle, and hide the console window.

## Root cause
When the CLI attempts to spawn the background daemon via `spawn(process.execPath, [resolveCliPath(), ...])`, it feeds the npm-generated wrapper script to Node. Because Windows `CreateProcess` doesn't honor shebangs, it rejects the wrapper file execution resulting in the `EFTYPE` format error.

## Fix
Ensure the background daemon correctly spawns across all platforms without OS-specific conditionals by:
1. Creating `resolveCliScriptPath()` to get the absolute path to the underlying JavaScript bundle using `import.meta.url`.
2. Using `spawn(process.execPath, [resolveCliScriptPath(), ...])` to explicitly invoke Node with the true `.js` file instead of the wrapper.
3. Adding `windowsHide: true` to prevent a console window from popping up and hanging on Windows when the detached daemon starts.

## Changes
- `apps/cli/src/util/resolve.ts`: Export `resolveCliScriptPath()`
- `apps/cli/src/commands/lifecycle.ts`: Update `startWorker()` spawn logic
- `apps/cli/src/commands/worker.ts`: Update `startWorker()` spawn logic

## Test plan
- `pnpm typecheck` passes
- `pnpm build` passes
- Tested on Windows: `cavemem start` successfully launches the background daemon silently.
- Tested on Windows: `cavemem viewer` successfully auto-boots the daemon and opens the UI.

Closes #11
Closes #18