### PR TITLE
fix(config): swap inverted search.alpha description

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -83,7 +83,7 @@ export const SettingsSchema = z
           .min(0)
           .max(1)
           .default(0.5)
-          .describe('Hybrid rank weight: 0 = pure BM25, 1 = pure cosine, 0.5 = balanced.'),
+          .describe('Hybrid rank weight: 0 = pure cosine, 1 = pure BM25, 0.5 = balanced.'),
         defaultLimit: z
           .number()
           .int()


### PR DESCRIPTION
Fixes #26

The `search.alpha` description in `schema.ts` had 0 and 1 swapped. The ranker does `alpha * bm25 + (1 - alpha) * cosine`, so alpha=1 is pure keyword and alpha=0 is pure vector. The description said the opposite.

Nobody hit this at the default 0.5 since it is symmetric, but anyone deliberately tuning toward one end would get confused by the help text.

### What changed

One string in `packages/config/src/schema.ts`:

```diff
- Hybrid rank weight: 0 = pure BM25, 1 = pure cosine, 0.5 = balanced.
+ Hybrid rank weight: 0 = pure cosine, 1 = pure BM25, 0.5 = balanced.
```

### How I verified

- Read `ranker.ts` line 23 to confirm the formula
- Checked the ranker comment (line 9) already says `alpha=1 → pure keyword`
- Checked `ranker.test.ts` — `alpha=1 prefers keyword` and `alpha=0 prefers vector` both pass and agree with the fix
- All four gates green: `pnpm typecheck && pnpm lint && pnpm test && pnpm build`