### PR TITLE
fix(cli): preserve memory data in export and import

### DIFF
--- a/.changeset/tender-caves-dance.md
+++ b/.changeset/tender-caves-dance.md
@@ -1,0 +1,6 @@
+---
+"cavemem": patch
+"@cavemem/storage": patch
+---
+
+Fix JSONL backup restore by allowing readonly exports and preserving metadata, summaries, and session end timestamps on import.

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -4,6 +4,8 @@ import { loadSettings, resolveDataDir } from '@cavemem/config';
 import { Storage } from '@cavemem/storage';
 import type { Command } from 'commander';
 
+type JsonRecord = { type: string } & Record<string, unknown>;
+
 export function registerExportCommand(program: Command): void {
   program
     .command('export <out>')
@@ -16,6 +18,9 @@ export function registerExportCommand(program: Command): void {
       const lines: string[] = [];
       for (const sess of s.listSessions(10000)) {
         lines.push(JSON.stringify({ type: 'session', ...sess }));
+        for (const summary of s.listSummaries(sess.id)) {
+          lines.push(JSON.stringify({ type: 'summary', ...summary }));
+        }
         for (const o of s.timeline(sess.id, undefined, 10000)) {
           lines.push(JSON.stringify({ type: 'observation', ...o }));
         }
@@ -34,24 +39,39 @@ export function registerExportCommand(program: Command): void {
       const lines = readFileSync(file, 'utf8').split(/\n+/).filter(Boolean);
       let n = 0;
       for (const line of lines) {
-        const rec = JSON.parse(line) as { type: string } & Record<string, unknown>;
+        const rec = JSON.parse(line) as JsonRecord;
         if (rec.type === 'session') {
+          const id = String(rec.id);
           s.createSession({
-            id: String(rec.id),
+            id,
             ide: String(rec.ide),
-            cwd: (rec.cwd as string | null) ?? null,
+            cwd: asNullableString(rec.cwd),
             started_at: Number(rec.started_at),
-            metadata: (rec.metadata as string | null) ?? null,
+            metadata: asNullableString(rec.metadata),
+          });
+          const endedAt = asOptionalTimestamp(rec.ended_at);
+          if (endedAt !== undefined) s.endSession(id, endedAt);
+          n++;
+        } else if (rec.type === 'summary') {
+          s.insertSummary({
+            session_id: String(rec.session_id),
+            scope: asSummaryScope(rec.scope),
+            content: String(rec.content),
+            compressed: asBooleanStored(rec.compressed),
+            intensity: asNullableString(rec.intensity),
+            ts: Number(rec.ts),
           });
           n++;
         } else if (rec.type === 'observation') {
+          const metadata = parseMetadata(rec.metadata);
           s.insertObservation({
             session_id: String(rec.session_id),
             kind: String(rec.kind),
             content: String(rec.content),
-            compressed: rec.compressed === 1 || rec.compressed === true,
-            intensity: (rec.intensity as string | null) ?? null,
+            compressed: asBooleanStored(rec.compressed),
+            intensity: asNullableString(rec.intensity),
             ts: Number(rec.ts),
+            ...(metadata !== undefined ? { metadata } : {}),
           });
           n++;
         }
@@ -59,4 +79,40 @@ export function registerExportCommand(program: Command): void {
       s.close();
       process.stdout.write(`imported ${n} records\n`);
     });
+}
+
+function asNullableString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+function asBooleanStored(value: unknown): boolean {
+  return value === 1 || value === true;
+}
+
+function asOptionalTimestamp(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  const ts = Number(value);
+  return Number.isFinite(ts) ? ts : undefined;
+}
+
+function asSummaryScope(value: unknown): 'turn' | 'session' {
+  if (value === 'turn' || value === 'session') return value;
+  throw new Error(`Invalid summary scope: ${String(value)}`);
+}
+
+function parseMetadata(value: unknown): Record<string, unknown> | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (isRecord(value)) return value;
+  if (typeof value !== 'string') return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/apps/cli/test/export-import.test.ts
+++ b/apps/cli/test/export-import.test.ts
@@ -1,0 +1,167 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Storage } from '@cavemem/storage';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createProgram } from '../src/index.js';
+
+let dir: string;
+let oldHome: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'cavemem-cli-export-'));
+  oldHome = process.env.HOME;
+  process.env.HOME = join(dir, 'home');
+  mkdirSync(join(process.env.HOME, '.cavemem'), { recursive: true });
+});
+
+afterEach(() => {
+  if (oldHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = oldHome;
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('cavemem export/import', () => {
+  it('round-trips sessions, observations, summaries, metadata, and ended_at', async () => {
+    const sourceDir = join(dir, 'source');
+    const targetDir = join(dir, 'target');
+    writeSettings(sourceDir);
+
+    const source = new Storage(join(sourceDir, 'data.db'));
+    source.createSession({
+      id: 'sess-export',
+      ide: 'claude-code',
+      cwd: '/repo',
+      started_at: 111,
+      metadata: '{"agent":"test"}',
+    });
+    source.insertSummary({
+      session_id: 'sess-export',
+      scope: 'turn',
+      content: 'turn summary',
+      compressed: true,
+      intensity: 'full',
+      ts: 222,
+    });
+    source.insertSummary({
+      session_id: 'sess-export',
+      scope: 'session',
+      content: 'session summary',
+      compressed: true,
+      intensity: 'full',
+      ts: 333,
+    });
+    source.insertObservation({
+      session_id: 'sess-export',
+      kind: 'tool_use',
+      content: 'Bash listed /tmp',
+      compressed: true,
+      intensity: 'full',
+      ts: 444,
+      metadata: { tool: 'Bash', nested: { ok: true } },
+    });
+    source.endSession('sess-export', 555);
+    source.close();
+
+    const backup = join(dir, 'backup.jsonl');
+    await createProgram().parseAsync(['node', 'cavemem', 'export', backup]);
+
+    const exported = readJsonl(backup);
+    expect(exported.map((r) => r.type)).toEqual(['session', 'summary', 'summary', 'observation']);
+
+    writeSettings(targetDir);
+    await createProgram().parseAsync(['node', 'cavemem', 'import', backup]);
+
+    const target = new Storage(join(targetDir, 'data.db'));
+    try {
+      expect(target.getSession('sess-export')).toMatchObject({
+        id: 'sess-export',
+        ide: 'claude-code',
+        cwd: '/repo',
+        started_at: 111,
+        ended_at: 555,
+        metadata: '{"agent":"test"}',
+      });
+      expect(
+        target
+          .listSummaries('sess-export')
+          .map((s) => s.content)
+          .sort(),
+      ).toEqual(['session summary', 'turn summary']);
+      const observations = target.timeline('sess-export', undefined, 10);
+      expect(observations).toHaveLength(1);
+      expect(observations[0]?.metadata).toBe('{"tool":"Bash","nested":{"ok":true}}');
+    } finally {
+      target.close();
+    }
+  });
+
+  it('imports legacy JSONL metadata strings and session timestamps', async () => {
+    const targetDir = join(dir, 'legacy-target');
+    const backup = join(dir, 'legacy.jsonl');
+    writeFileSync(
+      backup,
+      [
+        JSON.stringify({
+          type: 'session',
+          id: 'legacy',
+          ide: 'codex',
+          cwd: null,
+          started_at: 10,
+          ended_at: 20,
+          metadata: null,
+        }),
+        JSON.stringify({
+          type: 'summary',
+          session_id: 'legacy',
+          scope: 'turn',
+          content: 'legacy summary',
+          compressed: 1,
+          intensity: 'full',
+          ts: 30,
+        }),
+        JSON.stringify({
+          type: 'observation',
+          session_id: 'legacy',
+          kind: 'tool_use',
+          content: 'legacy content',
+          compressed: 1,
+          intensity: 'full',
+          ts: 40,
+          metadata: '{"tool":"Edit"}',
+        }),
+      ].join('\n'),
+    );
+
+    writeSettings(targetDir);
+    await createProgram().parseAsync(['node', 'cavemem', 'import', backup]);
+
+    const target = new Storage(join(targetDir, 'data.db'));
+    try {
+      expect(target.getSession('legacy')?.ended_at).toBe(20);
+      expect(target.listSummaries('legacy')).toHaveLength(1);
+      expect(target.timeline('legacy', undefined, 10)[0]?.metadata).toBe('{"tool":"Edit"}');
+    } finally {
+      target.close();
+    }
+  });
+});
+
+function writeSettings(dataDir: string): void {
+  if (!process.env.HOME) throw new Error('HOME missing');
+  writeFileSync(
+    join(process.env.HOME, '.cavemem', 'settings.json'),
+    `${JSON.stringify({ dataDir, embedding: { provider: 'none' } })}\n`,
+  );
+}
+
+function readJsonl(path: string): Array<{ type: string }> {
+  expect(existsSync(path)).toBe(true);
+  return readFileSync(path, 'utf8')
+    .split(/\n+/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { type: string });
+}

--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -21,7 +21,9 @@ export class Storage {
   constructor(dbPath: string, opts: StorageOptions = {}) {
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new Database(dbPath, opts.readonly ? { readonly: true } : {});
-    this.db.exec(SCHEMA_SQL);
+    if (!opts.readonly) {
+      this.db.exec(SCHEMA_SQL);
+    }
   }
 
   close(): void {

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -38,6 +38,26 @@ describe('Storage', () => {
     expect(rows[0]?.compressed).toBe(1);
   });
 
+  it('opens an existing database in readonly mode without schema writes', () => {
+    storage.createSession({
+      id: 'readonly-session',
+      ide: 'claude-code',
+      cwd: '/tmp',
+      started_at: 123,
+      metadata: null,
+    });
+    storage.close();
+
+    const readonly = new Storage(join(dir, 'test.db'), { readonly: true });
+    try {
+      expect(readonly.listSessions().map((s) => s.id)).toContain('readonly-session');
+    } finally {
+      readonly.close();
+    }
+
+    storage = new Storage(join(dir, 'test.db'));
+  });
+
   it('FTS search finds matches', () => {
     storage.createSession({
       id: 's',


### PR DESCRIPTION
Fixes #28

This PR fixes the JSONL backup/restore path. The current code has two problems:

- `cavemem export` opens the DB in readonly mode, then `Storage` immediately runs schema setup and SQLite rejects the write
- `cavemem import` restores only sessions and observations, dropping summaries, observation metadata, and session `ended_at`

That made backup/restore unreliable in a pretty boring but important way: either the backup failed, or the restore came back missing data.

## What changed

- `Storage` now skips schema initialization when opened with `readonly: true`
- `cavemem export` now includes summary records
- `cavemem import` now restores:
  - session `ended_at`
  - summaries
  - observation metadata
- import accepts metadata as either a JSON string or an object
- added regression tests for readonly export and full JSONL round-trip
- added a patch changeset for `cavemem` and `@cavemem/storage`

## Notes

Import still bypasses `MemoryStore` on purpose. The backup already contains persisted records, including compressed content, so re-running compression during restore would be the wrong layer.

Embeddings are not included in the JSONL export. They are derived data and can be rebuilt by the worker/reindex path.