### PR TITLE
fix(installers): quote Windows paths in hook commands even without spaces

### DIFF
--- a/packages/installers/src/fs-utils.ts
+++ b/packages/installers/src/fs-utils.ts
@@ -18,11 +18,22 @@ export function writeJson(path: string, data: unknown): void {
 /**
  * Quote a path for embedding into a shell command string (e.g., Claude
  * Code hook `command` fields). Wraps in double quotes unless the path is
- * already a bare token with no whitespace or shell metacharacters. On
- * Windows, double quotes also protect backslashes from being consumed.
+ * already a bare token with no whitespace, shell metacharacters, or
+ * backslashes.
+ *
+ * Backslashes force quoting because on Windows the hook `command` string
+ * is frequently executed under Git Bash / MSYS-bash (e.g., when launched
+ * from Claude Code on Windows). MSYS argv parsing treats unquoted
+ * backslashes as escape introducers and strips them, turning a path like
+ *   C:\Users\foo\AppData\Roaming\npm\node_modules\cavemem\dist\index.js
+ * into
+ *   CUsersfooAppDataRoamingnpmnode_modulescavememdistindex.js
+ * which Node then resolves against cwd and fails with MODULE_NOT_FOUND.
+ * Quoting the path preserves the backslashes verbatim under both cmd.exe
+ * and MSYS-bash.
  */
 export function shellQuote(p: string): string {
-  if (/^[\w@%+=:,./\\-]+$/.test(p)) return p;
+  if (/^[\w@%+=:,./-]+$/.test(p)) return p;
   return `"${p.replace(/"/g, '\\"')}"`;
 }
 

--- a/packages/installers/test/installers.test.ts
+++ b/packages/installers/test/installers.test.ts
@@ -293,6 +293,28 @@ describe('claude-code installer', () => {
     });
   });
 
+  it('quotes Windows paths even when they contain no spaces (MSYS strips bare backslashes)', async () => {
+    // Realistic default install layout: no spaces in the cliPath, only
+    // backslashes. Previously the regex whitelist allowed `\\` through as a
+    // bare token, leaving the path unquoted. Under Git Bash / MSYS the
+    // backslashes were then stripped from argv and Node failed with
+    // `MODULE_NOT_FOUND: ...UsersUserAppData...index.js`.
+    const winCtx: InstallContext = {
+      ideConfigDir: home,
+      cliPath: 'C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\cavemem\\dist\\index.js',
+      nodeBin: 'C:\\Program Files\\nodejs\\node.exe',
+      dataDir: join(home, '.cavemem'),
+    };
+    await claudeCode.install(winCtx);
+    const settings = JSON.parse(readFileSync(settingsPath(), 'utf8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    const cmd = settings.hooks.SessionStart?.[0]?.hooks?.[0]?.command ?? '';
+    expect(cmd).toBe(
+      `"${winCtx.nodeBin}" "${winCtx.cliPath}" hook run session-start --ide claude-code`,
+    );
+  });
+
   it('detect returns true only when ~/.claude exists', async () => {
     expect(await claudeCode.detect(ctx)).toBe(false);
     mkdirSync(join(home, '.claude'));


### PR DESCRIPTION
## Problem

On Windows, every cavemem hook silently fails after a default install — `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `Stop`, `SessionEnd`. No observations or sessions are ever recorded. `cavemem status` shows `0 observations, 0 sessions` indefinitely.

Reproduction:

```
$ cavemem install --ide claude-code
$ # use Claude Code on Windows for a while
$ cavemem status
db:  ...data.db ✓ (0 observations, 0 sessions)
```

The session transcript contains:

```
Failed with non-blocking status code:
Error: Cannot find module 'C:\<cwd>\UsersUserAppDataRoamingnpmnode_modulescavememdistindex.js'
    code: 'MODULE_NOT_FOUND'
```

The path has had all backslashes stripped.

## Root cause

`packages/installers/src/claude-code.ts` passes both `nodeBin` and `cliPath` through `shellQuote` before splicing them into the hook `command` string. `shellQuote` (in `fs-utils.ts`) returned a bare token whenever the path matched `^[\w@%+=:,./\-]+$` — which **included** backslash. So a default Windows install path with no spaces

```
C:\Users\User\AppData\Roaming\npm\node_modules\cavemem\dist\index.js
```

was written into `~/.claude/settings.json` unquoted:

```json
\"C:\\Program Files\\nodejs\\node.exe\" C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\cavemem\\dist\\index.js hook run session-start --ide claude-code
```

(node.exe is quoted only because `Program Files` contains a space.)

When Claude Code on Windows executes the hook under Git Bash / MSYS-bash (the common shell environment when Claude Code is launched from a desktop app), MSYS argv parsing treats unquoted backslashes as escape introducers and strips them, turning the path into:

```
CUsersUserAppDataRoamingnpmnode_modulescavememdistindex.js
```

Node resolves that against the working directory and crashes with `MODULE_NOT_FOUND`. The hook returns non-zero, Claude Code marks it failed, and cavemem captures nothing.

## Fix

Drop `\` from the `shellQuote` whitelist (`packages/installers/src/fs-utils.ts`). Any path containing a backslash now gets wrapped in double quotes. Both `cmd.exe` and MSYS-bash preserve backslashes verbatim inside `\"...\"`, so the resulting command works under both shells.

Forward-slash paths (`/usr/bin/node`, `C:/Users/...`) still pass through unquoted — POSIX behavior unchanged.

After the fix, `cavemem install` writes:

```
\"C:\\Program Files\\nodejs\\node.exe\" \"C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\cavemem\\dist\\index.js\" hook run session-start --ide claude-code
```

The hook fires, observations land, `cavemem status` starts climbing.

## Test

Added `it('quotes Windows paths even when they contain no spaces …')` in `packages/installers/test/installers.test.ts`. The existing Windows test only covered paths with spaces (which are quoted regardless because of the space), so the bug shipped unnoticed. The new test uses the realistic default install layout — backslashes, no spaces — and asserts the path is double-quoted.

```
pnpm --filter @cavemem/installers test
✓ test/installers.test.ts (20 tests)
```

No other behavior changed; existing 19 tests still pass.

## Verified manually

On the affected Windows machine, after applying the fix and re-running `cavemem install --ide claude-code`:

- Hook command runs cleanly: \`{\"hook\":\"session-start\",\"ok\":true,\"ms\":6}\`
- `cavemem status` now reports observations and sessions accumulating with use.