### PR TITLE
fix(storage,cli): bump better-sqlite3 to ^12.10.0 for Node 24/25 prebuilts

### DIFF
--- a/.changeset/bump-better-sqlite3-node-25.md
+++ b/.changeset/bump-better-sqlite3-node-25.md
@@ -1,0 +1,20 @@
+---
+'@cavemem/storage': patch
+'cavemem': patch
+---
+
+Bump `better-sqlite3` to `^12.10.0` so prebuilt binaries cover Node 24 (ABI 133) and Node 25 (ABI 137).
+
+`better-sqlite3@11.x` ships prebuilts only up to Node 22, so installs on
+Node 24+ fall through to a source build via `node-gyp`. On Windows that
+requires Visual Studio Build Tools with the "Desktop development with C++"
+workload; without it `npm install -g cavemem` fails with
+`Could not find any Visual Studio installation to use`.
+
+`better-sqlite3@12.10.0` publishes a `node-v137-win32-x64` prebuilt
+(and matching Linux/macOS variants), so `npm install -g cavemem` succeeds
+on Node 25 without any native toolchain.
+
+The 12.x major dropped Node.js 18 only — `engines.node >= 20.0.0` is
+unchanged, and no API used by `@cavemem/storage` (`prepare`, `run`, `get`,
+`all`, `exec`, `transaction`, `pragma`) changed between 11.x and 12.x.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "commander": "^12.1.0",
     "kleur": "^4.1.5",
-    "better-sqlite3": "^11.5.0",
+    "better-sqlite3": "^12.10.0",
     "hono": "^4.6.10",
     "@hono/node-server": "^1.13.7",
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "@cavemem/config": "workspace:*",
-    "better-sqlite3": "^11.5.0"
+    "better-sqlite3": "^12.10.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.11",
+    "@types/better-sqlite3": "^7.6.13",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
     "vitest": "^2.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.0.0
         version: 1.29.0(zod@3.25.76)
       better-sqlite3:
-        specifier: ^11.5.0
-        version: 11.10.0
+        specifier: ^12.10.0
+        version: 12.10.0
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -284,11 +284,11 @@ importers:
         specifier: workspace:*
         version: link:../config
       better-sqlite3:
-        specifier: ^11.5.0
-        version: 11.10.0
+        specifier: ^12.10.0
+        version: 12.10.0
     devDependencies:
       '@types/better-sqlite3':
-        specifier: ^7.6.11
+        specifier: ^7.6.13
         version: 7.6.13
       tsup:
         specifier: ^8.3.5
@@ -1071,8 +1071,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -2823,7 +2824,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3


### PR DESCRIPTION
## Summary

- Bump `better-sqlite3` from `^11.5.0` → `^12.10.0` in both `@cavemem/storage` and the `cavemem` CLI package
- Adds a changeset (`patch` for both)

## Why

`better-sqlite3@11.x` publishes prebuilts only up to Node 22. On Node 24 (ABI 133) and Node 25 (ABI 137) `npm install -g cavemem` falls through to a `node-gyp` source build, which on Windows requires Visual Studio Build Tools with the "Desktop development with C++" workload. Without it the install fails with:

```
gyp ERR! find VS Could not find any Visual Studio installation to use
```

`better-sqlite3@12.10.0` publishes `node-v137-win32-x64` and matching Linux/macOS prebuilts, so the install succeeds out of the box on Node 25 with no native toolchain.

## Compatibility

The only break in the `11.x` → `12.x` major was dropping Node 18 support. `engines.node` already requires `>=20.0.0`, so no engine bump is needed. None of the better-sqlite3 APIs used in `@cavemem/storage` (`prepare`, `run`, `get`, `all`, `exec`, `transaction`, `pragma`) changed across the major.

## Test plan

- [x] `pnpm install` — clean resolution, lockfile regenerated
- [x] `pnpm typecheck` — all 11 workspace projects pass
- [x] `pnpm -F @cavemem/storage test` — 7/7 vitest tests pass against 12.10.0
- [x] `pnpm build` — full monorepo builds clean
- [x] Manual smoke: `node apps/cli/dist/index.js doctor` runs on Node 25.9.0 + Windows 11 (ABI 137 prebuilt loaded, no source build attempted)
- [ ] Maintainer: please re-run `pnpm test` on Linux/macOS CI to confirm cross-platform parity

## Repro of the original failure

```
$ node --version
v25.9.0
$ npm install -g cavemem
...
gyp ERR! find VS Could not find any Visual Studio installation to use
npm error gyp ERR! cwd .../node_modules/cavemem/node_modules/better-sqlite3
npm error gyp ERR! $npm_package_version 11.10.0
```

After the bump, the same command succeeds without requiring VS Build Tools.