### PR TITLE
fix(installers): normalize Windows paths in Claude Code hook commands

### DIFF
--- a/.changeset/fix-windows-hook-paths.md
+++ b/.changeset/fix-windows-hook-paths.md
@@ -1,0 +1,25 @@
+---
+'@cavemem/installers': patch
+'cavemem': patch
+---
+
+Fix Windows hook commands silently failing in Claude Code (#43).
+
+The Claude Code installer wrote hook command strings using Windows
+backslash paths (`C:\Users\hp\…\node.exe …`). Claude Code runs hook
+commands through bash on Windows (git-bash via MINGW64). Bash applies
+escape processing to the string and drops any backslash followed by an
+undefined-escape character — turning `C:\Users\hp\scoop\…` into
+`C:Usershpscoop…`, so every hook fired with:
+
+```
+/usr/bin/bash: line 1: C:Usershpscoopappsnodejscurrentnode.exe:
+  command not found
+```
+
+Fixed by normalizing paths to forward slashes (new `posixPath()` helper
+in `@cavemem/installers`) before quoting them into the shell-string
+`command` field. Windows `CreateProcess` accepts forward-slash paths,
+so this works in cmd.exe, PowerShell, and bash with no platform-conditional
+logic. The MCP `command` + `args[]` entry is unaffected because it's a
+direct spawn (no shell).

--- a/packages/installers/src/claude-code.ts
+++ b/packages/installers/src/claude-code.ts
@@ -1,7 +1,7 @@
 import { copyFileSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { deepMerge, readJson, shellQuote, writeJson } from './fs-utils.js';
+import { deepMerge, posixPath, readJson, shellQuote, writeJson } from './fs-utils.js';
 import type { InstallContext, Installer } from './types.js';
 
 interface ClaudeHookEntry {
@@ -50,11 +50,14 @@ export const claudeCode: Installer = {
     const messages: string[] = [];
     const settingsPath = settingsFile();
     const mcpPath = mcpFile();
-    // Hook commands are shell strings, so nodeBin + cliPath must be quoted —
-    // Windows npm installs land under paths like C:\Users\...\AppData that
-    // may contain spaces. Both cmd.exe and sh treat "..." as one argv token.
-    const nodeBin = shellQuote(ctx.nodeBin);
-    const cliPath = shellQuote(ctx.cliPath);
+    // Hook commands are shell strings, so nodeBin + cliPath must be both
+    // forward-slash-normalized AND quoted. Normalization first because bash
+    // would silently eat backslashes (`C:\Users\hp` → `C:Usershp`); quoting
+    // second because Windows npm installs land under paths like
+    // C:\Users\...\AppData that may contain spaces — `"..."` keeps the path
+    // as one argv token in both cmd.exe and sh.
+    const nodeBin = shellQuote(posixPath(ctx.nodeBin));
+    const cliPath = shellQuote(posixPath(ctx.cliPath));
 
     // ---- hooks → ~/.claude/settings.json: append to existing arrays ----
     const settings = readJson<ClaudeSettings>(settingsPath, {});

--- a/packages/installers/src/fs-utils.ts
+++ b/packages/installers/src/fs-utils.ts
@@ -16,13 +16,30 @@ export function writeJson(path: string, data: unknown): void {
 }
 
 /**
+ * Normalize a path to forward-slash form. Windows accepts forward slashes
+ * in every API we hand the path to (CreateProcess, cmd.exe, PowerShell,
+ * Node spawn), and unlike backslashes they survive intact when the path
+ * is later interpolated into a shell command string and passed through
+ * bash. Use this on every path that ends up inside a shell `command`
+ * field (e.g., Claude Code hooks). Paths that go into a `command` +
+ * `args[]` spawn (no shell) don't need it.
+ */
+export function posixPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/**
  * Quote a path for embedding into a shell command string (e.g., Claude
  * Code hook `command` fields). Wraps in double quotes unless the path is
- * already a bare token with no whitespace or shell metacharacters. On
- * Windows, double quotes also protect backslashes from being consumed.
+ * already a bare token with no whitespace or shell metacharacters.
+ *
+ * Callers must pass a forward-slash-normalized path (see `posixPath`).
+ * Embedding raw Windows backslash paths in a bash command string causes
+ * silent collapse — bash drops every `\<letter>` that isn't a defined
+ * escape, turning `C:\Users\hp\node.exe` into `C:Usershpnode.exe`.
  */
 export function shellQuote(p: string): string {
-  if (/^[\w@%+=:,./\\-]+$/.test(p)) return p;
+  if (/^[\w@%+=:,./-]+$/.test(p)) return p;
   return `"${p.replace(/"/g, '\\"')}"`;
 }
 

--- a/packages/installers/test/installers.test.ts
+++ b/packages/installers/test/installers.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { claudeCode } from '../src/claude-code.js';
 import { codex } from '../src/codex.js';
 import { cursor } from '../src/cursor.js';
-import { deepMerge } from '../src/fs-utils.js';
+import { deepMerge, posixPath } from '../src/fs-utils.js';
 import { openCode } from '../src/opencode.js';
 import { getInstaller, installers } from '../src/registry.js';
 import type { InstallContext } from '../src/types.js';
@@ -57,6 +57,18 @@ describe('registry', () => {
   });
   it('getInstaller throws on unknown id', () => {
     expect(() => getInstaller('nope')).toThrow(/Unknown IDE/);
+  });
+});
+
+describe('posixPath', () => {
+  it('replaces backslashes with forward slashes', () => {
+    expect(posixPath('C:\\Users\\hp\\node.exe')).toBe('C:/Users/hp/node.exe');
+  });
+  it('is a no-op for already-POSIX paths', () => {
+    expect(posixPath('/usr/local/bin/node')).toBe('/usr/local/bin/node');
+  });
+  it('handles mixed separators', () => {
+    expect(posixPath('C:\\Users/hp\\node.exe')).toBe('C:/Users/hp/node.exe');
   });
 });
 
@@ -267,7 +279,7 @@ describe('claude-code installer', () => {
     expect(claudeJson.mcpServers.cavemem).toBeUndefined();
   });
 
-  it('quotes paths with spaces in hook command strings (Windows)', async () => {
+  it('normalizes and quotes Windows paths in hook command strings', async () => {
     const winCtx: InstallContext = {
       ideConfigDir: home,
       cliPath: 'C:\\Users\\Some User\\AppData\\Roaming\\npm\\node_modules\\cavemem\\dist\\index.js',
@@ -282,15 +294,40 @@ describe('claude-code installer', () => {
       mcpServers: Record<string, { command: string; args: string[] }>;
     };
     const cmd = settings.hooks.SessionStart?.[0]?.hooks?.[0]?.command ?? '';
+    // Forward-slash form survives bash escape processing (backslashes would
+    // be eaten — `\U`, `\h`, `\s` are undefined escapes in bash double-quoted
+    // strings); double quotes still wrap because of the embedded space in
+    // "Some User" and "Program Files".
     expect(cmd).toBe(
-      `"${winCtx.nodeBin}" "${winCtx.cliPath}" hook run session-start --ide claude-code`,
+      '"C:/Program Files/nodejs/node.exe" "C:/Users/Some User/AppData/Roaming/npm/node_modules/cavemem/dist/index.js" hook run session-start --ide claude-code',
     );
-    // MCP entry is a structured shape, so no quoting needed there — Claude
-    // spawns command + args directly.
+    // No backslashes survive in the shell-string command.
+    expect(cmd).not.toMatch(/\\/);
+    // MCP entry is a structured spawn (command + args), so the original
+    // Windows-style path is preserved verbatim — no shell, no escape risk.
     expect(claudeJson.mcpServers.cavemem).toEqual({
       command: winCtx.nodeBin,
       args: [winCtx.cliPath, 'mcp'],
     });
+  });
+
+  it('normalizes Windows paths with no spaces (no quoting needed)', async () => {
+    const winCtx: InstallContext = {
+      ideConfigDir: home,
+      cliPath: 'C:\\Users\\hp\\scoop\\persist\\nodejs\\bin\\node_modules\\cavemem\\dist\\index.js',
+      nodeBin: 'C:\\Users\\hp\\scoop\\apps\\nodejs\\current\\node.exe',
+      dataDir: join(home, '.cavemem'),
+    };
+    await claudeCode.install(winCtx);
+    const settings = JSON.parse(readFileSync(settingsPath(), 'utf8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+    const cmd = settings.hooks.Stop?.[0]?.hooks?.[0]?.command ?? '';
+    // No spaces → bare token, no quoting; still forward-slashed.
+    expect(cmd).toBe(
+      'C:/Users/hp/scoop/apps/nodejs/current/node.exe C:/Users/hp/scoop/persist/nodejs/bin/node_modules/cavemem/dist/index.js hook run stop --ide claude-code',
+    );
+    expect(cmd).not.toMatch(/\\/);
   });
 
   it('detect returns true only when ~/.claude exists', async () => {


### PR DESCRIPTION
Closes #43.

## Summary

- Adds `posixPath()` helper to `@cavemem/installers` (replaces backslashes with forward slashes)
- Normalizes `nodeBin` + `cliPath` in `claude-code.ts` before they are quoted into the shell-string `command` field
- Updates the existing Windows-path test to assert forward-slash output, adds two more (`posixPath` unit tests + a no-spaces Windows case)
- Adds changeset entry

## Why

On Windows, Claude Code runs hook commands through bash (git-bash via MINGW64). The installer was writing hook commands as raw Windows paths:

```json
"command": "C:\Users\hp\scoop\apps\nodejs\current\node.exe C:\Users\hp\scoop\persist\nodejs\bin\node_modules\cavemem\dist\index.js hook run stop --ide claude-code"
```

Bash's escape processing inside double-quoted strings drops every `\<letter>` that isn't a defined escape (`\$`, `\`, `\"`, `` \` ``). `\U`, `\h`, `\s`, `\a`, `\n`, `\p`, `\b`, `\d` are all undefined → backslash silently consumed. By the time `execve()` runs:

```
/usr/bin/bash: line 1: C:Usershpscoopappsnodejscurrentnode.exe: command not found
```

All five hooks (`SessionStart`, `UserPromptSubmit`, `PostToolUse`, `Stop`, `SessionEnd`) failed identically on first fire.

## How

`packages/installers/src/fs-utils.ts` gains:

```ts
export function posixPath(p: string): string {
  return p.replace(/\/g, '/');
}
```

`packages/installers/src/claude-code.ts` calls it on both paths before `shellQuote`:

```ts
const nodeBin = shellQuote(posixPath(ctx.nodeBin));
const cliPath = shellQuote(posixPath(ctx.cliPath));
```

Result on Windows:

```json
"command": "C:/Users/hp/scoop/apps/nodejs/current/node.exe C:/Users/hp/scoop/persist/nodejs/bin/node_modules/cavemem/dist/index.js hook run stop --ide claude-code"
```

Windows `CreateProcess` accepts forward-slash paths in cmd.exe, PowerShell, and bash, so no platform-conditional logic is needed. The MCP server entry under `~/.claude.json` is unaffected — it uses `command` + `args[]` (direct spawn, no shell).

I also dropped `\` from `shellQuote`'s bare-token regex and updated its comment, since the regex was effectively claiming "backslash in a bare token is safe in a shell command" — true for cmd.exe, false for bash, and we now never feed it backslashes anyway.

## Test plan

- [x] `pnpm -F @cavemem/installers test` — 23/23 pass (was 19; 1 replaced + 4 new)
- [x] `pnpm typecheck` — all 11 workspace projects clean
- [x] `pnpm -F @cavemem/installers build` + `pnpm -F cavemem build` succeed
- [x] Local repro confirmed pre-fix on Node 25 / Windows 11 / git-bash: backslash command collapsed, exit 127 from bash; with manual forward-slash rewrite, hook fires in ~20 ms
- [ ] Maintainer: please re-run `pnpm test` on macOS / Linux CI to confirm no platform regressions (the new tests use literal Windows-style strings so they execute identically everywhere)

## Out of scope (follow-ups)

- `packages/installers/src/codex.ts:105` has the same bug class — it interpolates `${ctx.nodeBin} ${ctx.cliPath}` into a shell command without quoting or normalization. Keeping this PR Claude-Code-focused per the issue scope; happy to file a separate PR for codex if interest.
- The reported install path (per issue #43) used `~/.claude/settings.json` for both hooks AND MCP. The current installer already migrates `mcpServers` out to `~/.claude.json`, so that part needed no change.

## How to verify locally (Windows)

```
$ pnpm -F @cavemem/installers test
# 23/23 pass; new tests pin the forward-slash output exactly.
```

Or end-to-end:

```
$ cavemem uninstall
$ cavemem install
$ jq '.hooks.Stop[0].hooks[0].command' ~/.claude/settings.json
# Output uses forward slashes, no backslashes.
```